### PR TITLE
Protect *readtable*, in case the image is running other programs

### DIFF
--- a/coselleliza1969and1972.lisp
+++ b/coselleliza1969and1972.lisp
@@ -249,6 +249,7 @@
 
 (eval-when
  (:compile-toplevel :load-toplevel :execute)
+ (setq *readtable* (copy-readtable ()))
  (set-syntax-from-char #\' #\a *readtable*))
 
 ;;; ===================================================================================


### PR DESCRIPTION
Without this setq, the readtable in use when the file is loaded will be altered. This may be irritating to users who are using their lisp image for multiple purposes. 

When a file is loaded, the global variable *readtable* is given a new binding, but the object it is bound to remains the same.

By setting *readtable* to a new object, we avoid mutating the original -- and because *readtable* is rebound for the duration of loading the file, our new readtable is in effect popped off and the old one is restored when the scope of that binding is exited.
