### PR TITLE
Double Quotes read as multiple escape characters

### DIFF
--- a/coselleliza1969and1972.lisp
+++ b/coselleliza1969and1972.lisp
@@ -269,6 +269,7 @@
 (eval-when
  (:compile-toplevel :load-toplevel :execute)
  (setq *readtable* (copy-readtable ()))
+ (set-syntax-from-char #\" #\| *readtable*)
  (set-syntax-from-char #\' #\a *readtable*))
 
 ;;; ===================================================================================
@@ -279,14 +280,11 @@
 
 ;;; /DOCFNS/   31 JULY 1969  1007:42                             PAGE 1
 
-#|
-  (PROGN (PRIN1 (QUOTE FILE" CREATED ")
-      T)
-    (PRIN1 (QUOTE 08/22/68" 1522:26")
-      T)
-    (TERPRI T))
-|#
-
+(PROGN (PRIN1 (QUOTE FILE" CREATED ")
+              T)
+       (PRIN1 (QUOTE 08/22/68" 1522:26")
+              T)
+       (TERPRI T))
 (DEFINEQ
 
 (DOCTOR


### PR DESCRIPTION
I took a look at issue #5 and was surprised to find a one-liner for it. 

I wasn't sure if we wanted to re-enable the printing of the 1968 header or not (this patch would re-enable it.)
